### PR TITLE
CI: make use of the canonical/setup-lxd action

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      # Setup LXD + Docker fixes
+      - uses: canonical/setup-lxd@v0.1.0
+        with:
+          channel: latest/stable  # switch from distro's LTS channel to latest/stable
       - run: |
           git fetch --unshallow --tags
       # Install openvswitch-switch to make the OVS integration tests work
@@ -28,16 +32,11 @@ jobs:
           sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
           sudo apt update
           sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
-          sudo snap install lxd
-          sudo lxd init --auto --storage-backend=dir
       # work around LP: #1878225 as fallback
       - name: Preparing autopkgtest-build-lxd
         run: |
-          # Fix Docker blocking LXD networking:
-          # https://discuss.linuxcontainers.org/t/9953/4
-          sudo iptables -I DOCKER-USER  -j ACCEPT
           sudo patch /usr/bin/autopkgtest-build-lxd .github/workflows/snapd.patch
-          sudo autopkgtest-build-lxd ubuntu-daily:jammy
+          autopkgtest-build-lxd ubuntu-daily:jammy
       - name: Prepare test
         run: |
           pull-lp-source netplan.io
@@ -48,4 +47,4 @@ jobs:
         run: |
           # using --setup-commands temporarily to install:
           # cmocka/pytest/rich/ethtool until they become proper test-deps
-          sudo autopkgtest . --setup-commands='apt -y install ethtool python3-rich python3-pytest python3-pytest-cov libcmocka-dev' -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64
+          autopkgtest . --setup-commands='apt -y install ethtool python3-rich python3-pytest python3-pytest-cov libcmocka-dev' -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64


### PR DESCRIPTION
This will setup LXD with proper permissions and adopt the firewall rules to accomodate for the pre-installed docker application, e.g.: https://discuss.linuxcontainers.org/t/9953/4


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

